### PR TITLE
Skip input schema validation for Windows

### DIFF
--- a/docs/wss_tools/install.rst
+++ b/docs/wss_tools/install.rst
@@ -51,7 +51,7 @@ AstroConda channel you added earlier::
 Now, you can install ``wss_tools`` using ``pip`` (there was a decision not
 to include it in AstroConda)::
 
-    pip install git+https://github.com/STScI-JWST/wss_tools.git@0.3.3
+    pip install git+https://github.com/STScI-JWST/wss_tools.git@0.3.4
 
 Dependencies installed using ``conda install`` above can be updated from time
 to time using ``conda update <packagename>`` command as needed. As for those

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ exclude = extern,sphinx
 
 [metadata]
 package_name = wss_tools
-version = 0.3.3.dev
+version = 0.3.4.dev
 description = Python tools for WSS
 long_description = Python tools for JWST Wavefront Sensing Software
 author = Pey Lian Lim

--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -11,6 +11,7 @@ from astropy.extern.six.moves import map
 # STDLIB
 import glob
 import os
+import platform
 import shutil
 import sys
 
@@ -66,6 +67,7 @@ def main(args):
 
     ValueError
         Input XML fails to validate built-in schema.
+        Validation is skipped for Windows.
 
     """
     from stginga.gingawrapper import _locate_plugin
@@ -76,10 +78,12 @@ def main(args):
     if not os.path.exists(inputxml):
         raise OSError('{0} does not exist'.format(inputxml))
 
-    # Validate input XML (compare return code and display stderr if fails)
-    schema_v = qio.validate_input_xml(inputxml)
-    if schema_v[0] != 0:
-        raise ValueError(schema_v[2])
+    # Validate input XML (compare return code and display stderr if fails).
+    # Skipped for Windows because no xmllint.
+    if platform.system() != 'Windows':
+        schema_v = qio.validate_input_xml(inputxml)
+        if schema_v[0] != 0:
+            raise ValueError(schema_v[2])
 
     if '--nocopy' in args:
         nocopy = True


### PR DESCRIPTION
Skip input schema validation for Windows due to the lack of `xmllint` in Anaconda. Bump version for release.